### PR TITLE
로컬서버 슬랙 연동 테스트 방법 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Netlify의 AWS 계정으로 Lambda를 이용
 
 ### 로컬 개발
 
-```
+```sh
 npm run dev
 ```
 
@@ -27,7 +27,7 @@ api 엔드포인트 및 로직 추가
 
 ### 슬랙봇 프로토타이핑 코드
 
-```
+```sh
 .functions/tip-test/tip-test.js
 ```
 
@@ -39,7 +39,40 @@ URL : /.netlify/functions/tip-test
 
 netlify dev의 live 기능은 netlify 웹앱의 소유자만 쓸 수 있어, 다른 방법으로 시도
 
+#### 1. ngrok
+
+설치
+
+```sh
+brew cask install ngrok
+```
+
+```sh
+# 개발중인 로컬 서버가 3000 포트일 때
+ngrok http 3000
+
+# 출력 예시
+# Forwarding에 나오는 url을 슬랙 봇에서 로컬 서버를 바라 볼 수 있음
+# 예) https://97e8a361.ngrok.io
+#
+# ngrok by @inconshreveable
+#
+# Session Status                online
+# Session Expires               7 hours, 59 minutes
+# Version                       2.3.35
+# Region                        United States (us)
+# Web Interface                 http://127.0.0.1:4040
+# Forwarding                    http://97e8a361.ngrok.io -> http://#localhost:8888
+# Forwarding                    https://97e8a361.ngrok.io -> http://#localhost:8888
+```
+
+#### 2. Serveo
+
 [Serveo](https://serveo.net/) 로 로컬 서버에 접근가능한 URL 생성
+
+장점 : 설치가 필요 없음
+
+단점 : serveo 서버가 잘 죽음
 
 ```sh
 # 개발중인 로컬 서버가 localhost:3000일 때


### PR DESCRIPTION
### 무엇인가요?

로컬서버 슬랙 연동 테스트 방법에 ngrok을 이용한 방식을 추가했습니다.

### 왜 했나요?

serveo 서버가 죽고나서 복구가 안되고 있고, 이미 전에도 몇 번 죽고 복구가 느린걸로 확인되어 ngrok 방식을 추가했습니다.